### PR TITLE
fix: broken poetry deps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2094,4 +2094,4 @@ email = ["email-validator"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "b82ca0eb82ce30d8b2b891b948edde0df0c1d61d9ab731d323cf6464cbe3ab0b"
+content-hash = "ff89645975a84d8d7be78495e47a02e819bf6a133f9af0d4abc4c1381730fd89"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Xmartlabs' Python project template"
 authors = [{ name = "Xmartlabs", email = "getintouch@xmartlabs.com" }]
 readme = "README.md"
 requires-python = "^3.13"
-dependencies = ["asyncpg (>=0.30.0,<0.31.0)"]
+dependencies = []
 
 [tool.poetry]
 # TODO(remer): this can be removed when the source files are moved to project name folder within src
@@ -31,6 +31,7 @@ python-jose = "^3.3.0"
 sqladmin = "^0.18.0"
 sqlalchemy = "^2.0.31"
 uvicorn = "^0.30.3"
+asyncpg = "^0.30.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"


### PR DESCRIPTION
## Type of change

* [ ] Fix

## Description of the change
In PR #37, I added `asyncpg`, but apparently, this broke the entire `pyproject.toml`. As a result, if you tried to start from scratch, Poetry wouldn't install all dependencies, leaving the project broken. Now, I've added `asyncpg` manually, and everything works fine.

## Related PRs
#37 
