### PR TITLE
chore: fix dependabot file not supporting aliases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,21 +4,28 @@ version: 2
 updates:
   # Enable version updates for poetry
   - package-ecosystem: "pip"
-    # Shared configuration among all package ecosystems
-    <<: &package-setup
-      commit-message:
-        include: "scope"
-        prefix: "chore"
-      directory: "/"
-      labels:
-        - dependencies
-      reviewers:
-        - xmartlabs/python
-      schedule:
-        interval: "weekly"
+    commit-message:
+      include: "scope"
+      prefix: "chore"
+    directory: "/"
+    labels:
+      - dependencies
+    reviewers:
+      - xmartlabs/python
+    schedule:
+      interval: "weekly"
     # dependabot doesn't support poetry v2. See: https://github.com/dependabot/dependabot-core/issues/11237
     open-pull-requests-limit: 0
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
-    <<: *package-setup
+    commit-message:
+      include: "scope"
+      prefix: "chore"
+    directory: "/"
+    labels:
+      - dependencies
+    reviewers:
+      - xmartlabs/python
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Type of change

* [ ] Fix
* [ ] Story
* [x] Chore

## Description of the change
Fixing Dependabot yaml file, as it doesn't support YAML aliases: https://github.com/xmartlabs/python-template/runs/39472635464

## Related PRs
N/A
